### PR TITLE
Add estimated read time to Post details

### DIFF
--- a/TabloidMVC/Controllers/PostController.cs
+++ b/TabloidMVC/Controllers/PostController.cs
@@ -42,7 +42,7 @@ namespace TabloidMVC.Controllers
             PostDetailView pdv = new PostDetailView()
             {
                 Post = post,
-                ReadTime = WordCount % 365 == 0 ? WordCount / 365 : WordCount / 365 + 1
+                ReadTime = WordCount % 265 == 0 ? WordCount / 265 : WordCount / 265 + 1
             };
             
             return View(pdv);

--- a/TabloidMVC/Controllers/PostController.cs
+++ b/TabloidMVC/Controllers/PostController.cs
@@ -4,7 +4,9 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.VisualBasic;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Claims;
+using System.Text.RegularExpressions;
 using TabloidMVC.Models;
 using TabloidMVC.Models.ViewModels;
 using TabloidMVC.Repositories;
@@ -33,9 +35,17 @@ namespace TabloidMVC.Controllers
         {
             var post = _postRepository.GetPostById(id);
             
-                if (post == null)return NotFound();
+            if (post == null)return NotFound();
+
+            int WordCount = post.Content.Split(" ").Length;
+
+            PostDetailView pdv = new PostDetailView()
+            {
+                Post = post,
+                ReadTime = WordCount % 365 == 0 ? WordCount / 365 : WordCount / 365 + 1
+            };
             
-            return View(post);
+            return View(pdv);
         }
 
         public IActionResult Create()

--- a/TabloidMVC/Models/Post.cs
+++ b/TabloidMVC/Models/Post.cs
@@ -15,7 +15,6 @@ namespace TabloidMVC.Models
         public string Title { get; set; }
 
         [Required(ErrorMessage = "Please Enter a Content.")]
-        [MaxLength(255, ErrorMessage = "Your tag can't be longer than 50 characters."), MinLength(5, ErrorMessage = "Can't be empty.")]
         public string Content { get; set; }
 
         [DisplayName("Header Image URL")]

--- a/TabloidMVC/Models/ViewModels/PostDetailView.cs
+++ b/TabloidMVC/Models/ViewModels/PostDetailView.cs
@@ -1,0 +1,8 @@
+﻿namespace TabloidMVC.Models.ViewModels
+{
+    public class PostDetailView
+    {
+        public Post Post { get; set; }
+        public double ReadTime { get; set; }
+    }
+}

--- a/TabloidMVC/Views/Post/Details.cshtml
+++ b/TabloidMVC/Views/Post/Details.cshtml
@@ -15,6 +15,10 @@
                 <p class="text-secondary">Written by @Model.Post.UserProfile.DisplayName</p>
                 <p class="text-black-50">Published on @Html.DisplayFor(model => model.Post.PublishDateTime)</p>
             </div>
+            <div class="row justify-content-start">
+                @{ string minuteForm = Model.ReadTime == 1 ? "minute" : "minutes"; }
+                <p class="text-secondary">Estimated read time: @Model.ReadTime @minuteForm</p>
+            </div>
             <div class="row">
                 <a asp-action="Edit" asp-route-id="@Model.Post.Id" class="btn btn-outline-primary mx-1" title="Edit">
                     <i class="fas fa-pencil-alt"></i>

--- a/TabloidMVC/Views/Post/Details.cshtml
+++ b/TabloidMVC/Views/Post/Details.cshtml
@@ -1,47 +1,47 @@
-﻿@model TabloidMVC.Models.Post
+﻿@model TabloidMVC.Models.ViewModels.PostDetailView
 
 @{
-    ViewData["Title"] = $"Post - {Model.Title}";
+    ViewData["Title"] = $"Post - {Model.Post.Title}";
 }
 
 <div class="container pt-5">
     <div class="post">
         <section class="px-3">
             <div class="row justify-content-between">
-                <h1 class="text-secondary">@Model.Title</h1>
-                <h1 class="text-black-50">@Model.Category.Name</h1>
+                <h1 class="text-secondary">@Model.Post.Title</h1>
+                <h1 class="text-black-50">@Model.Post.Category.Name</h1>
             </div>
             <div class="row justify-content-between">
-                <p class="text-secondary">Written by @Model.UserProfile.DisplayName</p>
-                <p class="text-black-50">Published on @Html.DisplayFor(model => model.PublishDateTime)</p>
+                <p class="text-secondary">Written by @Model.Post.UserProfile.DisplayName</p>
+                <p class="text-black-50">Published on @Html.DisplayFor(model => model.Post.PublishDateTime)</p>
             </div>
             <div class="row">
-                <a asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-outline-primary mx-1" title="Edit">
+                <a asp-action="Edit" asp-route-id="@Model.Post.Id" class="btn btn-outline-primary mx-1" title="Edit">
                     <i class="fas fa-pencil-alt"></i>
                 </a>
-                <a asp-action="Delete" asp-route-id="@Model.Id" class="btn btn-outline-primary mx-1" title="Delete">
+                <a asp-action="Delete" asp-route-id="@Model.Post.Id" class="btn btn-outline-primary mx-1" title="Delete">
                     <i class="fas fa-trash"></i>
                 </a>
             </div>
         </section>
         <hr />
-        @if (!string.IsNullOrWhiteSpace(Model.ImageLocation))
+        @if (!string.IsNullOrWhiteSpace(Model.Post.ImageLocation))
         {
             <section class="row justify-content-center">
                 <div>
-                    <img src="@Model.ImageLocation" />
+                    <img src="@Model.Post.ImageLocation" />
                 </div>
             </section>
         }
         <section class="row post__content">
-            <p class="col-sm-12 mt-5">@Html.DisplayFor(model => model.Content)</p>
+            <p class="col-sm-12 mt-5">@Html.DisplayFor(model => model.Post.Content)</p>
         </section>
         <div class="row">
             <div class="m-1">
-                <a class="btn btn-primary" asp-controller="Comment" asp-action="Index" asp-route-id="@Model.Id">View Comments</a>
+                <a class="btn btn-primary" asp-controller="Comment" asp-action="Index" asp-route-id="@Model.Post.Id">View Comments</a>
             </div>
             <div class="m-1">
-                <a class="btn btn-primary" asp-controller="Comment" asp-action="Create" asp-route-id="@Model.Id">Add Comment</a>
+                <a class="btn btn-primary" asp-controller="Comment" asp-action="Create" asp-route-id="@Model.Post.Id">Add Comment</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
# Description
Added estimated read time to post details. To accomplish this, I crunched the numbers on the backend in the PostController, then passed the result alongside the post in a new PostDetailView model.
Fixes #23 
## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
# Testing Instructions
1. Run the app
2. Login as ```admin@example.com```
3. Go to Posts, then click the details view on an individual post
4. The read time will be displayed in the header, underneath the author name
Note: The formula is 265 WPM, so it takes that many words to increment the number
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
