### PR TITLE
Remove js-scroll-trigger class that prevents menu dropdown

### DIFF
--- a/TabloidMVC/Views/Shared/_Layout.cshtml
+++ b/TabloidMVC/Views/Shared/_Layout.cshtml
@@ -31,12 +31,12 @@
                                 <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Post" asp-action="Index">POSTS</a>
                             </li>
                             <li class="nav-item dropdown mx-0 mx-lg-1">
-                                <a class="nav-link dropdown-toggle py-3 px-0 px-lg-3 rounded js-scroll-trigger" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <a class="nav-link dropdown-toggle py-3 px-0 px-lg-3 rounded" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                     ADMIN TOOLS
                                 </a>
                                 <div class="dropdown-menu bg-secondary" aria-labelledby="navbarDropdownMenuLink">
-                                    <a class="dropdown-item py-3 px-0 px-lg-3 rounded bg-secondary text-white js-scroll-trigger" asp-area="" asp-controller="Category" asp-action="Index">CATEGORY MANAGEMENT</a>
-                                    <a class="dropdown-item py-3 px-0 px-lg-3 rounded bg-secondary text-white js-scroll-trigger" asp-area="" asp-controller="Tag" asp-action="Index">TAG MANAGEMENT</a>
+                                    <a class="dropdown-item py-3 px-0 px-lg-3 rounded bg-secondary text-white" asp-area="" asp-controller="Category" asp-action="Index">CATEGORY MANAGEMENT</a>
+                                    <a class="dropdown-item py-3 px-0 px-lg-3 rounded bg-secondary text-white" asp-area="" asp-controller="Tag" asp-action="Index">TAG MANAGEMENT</a>
                                 </div>
                             </li>
                             <li class="nav-item mx-0 mx-lg-1">


### PR DESCRIPTION
# Description
Removed the class on the dropdown menu that prevented Admin Tools from expanding when in a condensed menu.
Fixes #60 
## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
# Testing Instructions
1. Run the app and login
2. Check the Admin Tools menu in a full viewport
3. Check the Admin Tools menu in a smaller viewport, to where the full menu is a "hamburger" style menu
4. Make sure the menu expands and options are clickable
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
