### PR TITLE
Implement user deactivation

### DIFF
--- a/SQL/01_TabloidMVC_Create_DB.sql
+++ b/SQL/01_TabloidMVC_Create_DB.sql
@@ -1,4 +1,5 @@
 
+
 USE [master]
 
 IF db_id('TabloidMVC') IS NULl
@@ -36,6 +37,7 @@ CREATE TABLE [UserProfile] (
   [CreateDateTime] datetime NOT NULL,
   [ImageLocation] nvarchar(255),
   [UserTypeId] integer NOT NULL,
+  [Deactivated] BIT NOT NULL,
 
   CONSTRAINT [FK_User_UserType] FOREIGN KEY ([UserTypeId]) REFERENCES [UserType] ([Id])
 )

--- a/SQL/02_TabloidMVC_Seed_Data.sql
+++ b/SQL/02_TabloidMVC_Seed_Data.sql
@@ -21,10 +21,10 @@ SET IDENTITY_INSERT [Tag] OFF
 
 SET IDENTITY_INSERT [UserProfile] ON
 INSERT INTO [UserProfile] (
-	[Id], [FirstName], [LastName], [DisplayName], [Email], [CreateDateTime], [ImageLocation], [UserTypeId])
-VALUES (1, 'Admina', 'Strator', 'admin', 'admin@example.com', SYSDATETIME(), NULL, 1),
-	   (2, 'Rita', 'Book', 'bookie009', 'author@example.com', SYSDATETIME(), NULL, 2),
-	   (3, 'John Jacob', 'Jingleheimer Schmidt', 'hisnameismyname', 'jjjs@aol.com', SYSDATETIME(), NULL, 2);
+	[Id], [FirstName], [LastName], [DisplayName], [Email], [CreateDateTime], [ImageLocation], [UserTypeId], [Deactivated])
+VALUES (1, 'Admina', 'Strator', 'admin', 'admin@example.com', SYSDATETIME(), NULL, 1, 0),
+	   (2, 'Rita', 'Book', 'bookie009', 'author@example.com', SYSDATETIME(), NULL, 2, 0),
+	   (3, 'John Jacob', 'Jingleheimer Schmidt', 'hisnameismyname', 'jjjs@aol.com', SYSDATETIME(), NULL, 2, 0);
 SET IDENTITY_INSERT [UserProfile] OFF
 
 SET IDENTITY_INSERT [Post] ON

--- a/TabloidMVC/Controllers/UserProfileController.cs
+++ b/TabloidMVC/Controllers/UserProfileController.cs
@@ -10,6 +10,7 @@ using TabloidMVC.Repositories;
 
 namespace TabloidMVC.Controllers
 {
+    [Authorize]
     public class UserProfileController : Controller
     {
         private readonly IUserProfileRepository _userProfileRepository;
@@ -17,7 +18,7 @@ namespace TabloidMVC.Controllers
         {
             _userProfileRepository = userProfileRepository;
         }
-        [Authorize]
+
         // GET: UserProfileController
         public ActionResult Index()
         {
@@ -76,21 +77,26 @@ namespace TabloidMVC.Controllers
         // GET: UserProfileController/Delete/5
         public ActionResult Delete(int id)
         {
-            return View();
+            List<UserProfile> userProfiles = _userProfileRepository.GetAll();
+            UserProfile userProfile = userProfiles[1];
+            //UserProfile userProfile = _userProfileRepository.GetById(id);
+            return View(userProfile);
         }
 
         // POST: UserProfileController/Delete/5
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public ActionResult Delete(int id, IFormCollection collection)
+        public ActionResult Delete(int id, UserProfile userProfile)
         {
             try
             {
+                userProfile.Deactivated = true;
+                _userProfileRepository.Update(userProfile);
                 return RedirectToAction(nameof(Index));
             }
-            catch
+            catch (Exception ex)
             {
-                return View();
+                return View(userProfile);
             }
         }
     }

--- a/TabloidMVC/Controllers/UserProfileController.cs
+++ b/TabloidMVC/Controllers/UserProfileController.cs
@@ -84,9 +84,7 @@ namespace TabloidMVC.Controllers
         // GET: UserProfileController/Delete/5
         public ActionResult Delete(int id)
         {
-            List<UserProfile> userProfiles = _userProfileRepository.GetAll();
-            UserProfile userProfile = userProfiles[1];
-            //UserProfile userProfile = _userProfileRepository.GetById(id);
+            UserProfile userProfile = _userProfileRepository.GetById(id);
             return View(userProfile);
         }
 
@@ -101,7 +99,7 @@ namespace TabloidMVC.Controllers
                 _userProfileRepository.Update(userProfile);
                 return RedirectToAction(nameof(Index));
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 return View(userProfile);
             }

--- a/TabloidMVC/Models/UserProfile.cs
+++ b/TabloidMVC/Models/UserProfile.cs
@@ -32,6 +32,7 @@ namespace TabloidMVC.Models
         public int UserTypeId { get; set; }
         [DisplayName("User Type")]
         public UserType UserType { get; set; }
+        public bool Deactivated { get; set; }
         [DisplayName("Name")]
         public string FullName
         {

--- a/TabloidMVC/Repositories/IUserProfileRepository.cs
+++ b/TabloidMVC/Repositories/IUserProfileRepository.cs
@@ -8,5 +8,7 @@ namespace TabloidMVC.Repositories
         List<UserProfile> GetAll();
 
         UserProfile GetByEmail(string email);
+        void Update(UserProfile userProfile);
+
     }
 }

--- a/TabloidMVC/Views/UserProfile/Delete.cshtml
+++ b/TabloidMVC/Views/UserProfile/Delete.cshtml
@@ -11,23 +11,23 @@
 
         <form class="card-body" asp-action="Delete">
             <dl class="row">
-                <dt class="col-sm-2">
+                <dt class="col-sm-5">
                     @Html.DisplayNameFor(model => model.DisplayName)
                 </dt>
-                <dd class="col-sm-10">
+                <dd class="col-sm-7">
                     @Html.DisplayFor(model => model.DisplayName)
                     <input asp-for="DisplayName" type="hidden" />
                 </dd>
-                <dt class="col-sm-2">
+                <dt class="col-sm-5">
                     @Html.DisplayNameFor(model => model.FullName)
                 </dt>
-                <dd class="col-sm-10">
+                <dd class="col-sm-7">
                     @Html.DisplayFor(model => model.FullName)
                 </dd>
-                <dt class="col-sm-2">
+                <dt class="col-sm-5">
                     @Html.DisplayNameFor(model => model.Email)
                 </dt>
-                <dd class="col-sm-10">
+                <dd class="col-sm-7">
                     @Html.DisplayFor(model => model.Email)
                     <input asp-for="Email" type="hidden" />
                 </dd>

--- a/TabloidMVC/Views/UserProfile/Delete.cshtml
+++ b/TabloidMVC/Views/UserProfile/Delete.cshtml
@@ -1,0 +1,50 @@
+﻿@model TabloidMVC.Models.UserProfile
+
+@{
+    ViewData["Title"] = "Delete";
+}
+
+<div class="row justify-content-center">
+    <div class="card col-md-4">
+        <h4 class="mt-3 text-primary text-center card-title">Deactivate this user?</h4>
+        <p><strong>The user can be reactivated later.</strong></p>
+
+        <form class="card-body" asp-action="Delete">
+            <dl class="row">
+                <dt class="col-sm-2">
+                    @Html.DisplayNameFor(model => model.DisplayName)
+                </dt>
+                <dd class="col-sm-10">
+                    @Html.DisplayFor(model => model.DisplayName)
+                    <input asp-for="DisplayName" type="hidden" />
+                </dd>
+                <dt class="col-sm-2">
+                    @Html.DisplayNameFor(model => model.FullName)
+                </dt>
+                <dd class="col-sm-10">
+                    @Html.DisplayFor(model => model.FullName)
+                </dd>
+                <dt class="col-sm-2">
+                    @Html.DisplayNameFor(model => model.Email)
+                </dt>
+                <dd class="col-sm-10">
+                    @Html.DisplayFor(model => model.Email)
+                    <input asp-for="Email" type="hidden" />
+                </dd>
+                <dd>
+                    @* Additional fields needed to update the model *@
+                    <input asp-for="Id" type="hidden" />
+                    <input asp-for="FirstName" type="hidden" />
+                    <input asp-for="LastName" type="hidden" />
+                    <input asp-for="CreateDateTime" type="hidden" />
+                    <input asp-for="ImageLocation" type="hidden" />
+                    <input asp-for="UserTypeId" type="hidden" />
+                </dd>
+            </dl>
+            <div class="form-group">
+                <input type="submit" value="Deactivate" class="btn btn-danger btn-block" />
+                <a class="btn btn-primary btn-block" asp-controller="UserProfile" asp-action="Index">Cancel</a>
+            </div>
+        </form>
+    </div>
+</div>

--- a/TabloidMVC/Views/UserProfile/Index.cshtml
+++ b/TabloidMVC/Views/UserProfile/Index.cshtml
@@ -42,11 +42,10 @@
                         </a>
                         <a asp-action="Edit" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Edit">
                             <i class="fas fa-pencil-alt"></i>
-                        </a>
-                        <a asp-action="Delete" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Delete">
+                        </a> *@
+                        <a asp-action="Delete" asp-route-id="@item.Id" class="btn btn-outline-danger mx-1" title="Delete">
                             <i class="fas fa-trash"></i>
-                        </a>
-                        *@
+                        </a>                       
                     </td>
                 </tr>
             }


### PR DESCRIPTION
# Description
Implemented ability to deactivate user through the User Profile manager. This required changing the database and UserProfile class to include a Deactivated bit/boolean value.
Fixes #26 
## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
# Testing Instructions
**Seed data is important on this one.** Once again, we will need the new items in the seed data going forward.
1. Run SQL scripts 1 and 2 to update the seed data
2. Run the program via VS debugger or ```dotnet run```
3. Login and navigate to Admin Tools > User Profiles
4. 'Delete' one of the user profiles. The program will ask for confirmation of the deactivation
5. Confirming will deactivate the account; canceling will take you back to the account list
6. Deactivated profiles are not visible in the program until the next ticket. To confirm, run ```SELECT * FROM UserProfile``` in a SQL script and observe that the value of ```Deactivated``` on the appropriate profile is now ```1```
Admins are all currently deleteable. This is addressed in a later ticket. It also doesn't matter, since rights have not yet been restricted.
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
