### PR TITLE
Prevent the loss of all admins

### DIFF
--- a/TabloidMVC/Controllers/UserProfileController.cs
+++ b/TabloidMVC/Controllers/UserProfileController.cs
@@ -72,6 +72,13 @@ namespace TabloidMVC.Controllers
         {
             try
             {
+                List<UserProfile> allAdmins = _userProfileRepository.GetAllActiveAdmins();
+                if (allAdmins.Count == 1 && evm.User.UserTypeId != 1)
+                {
+                    ModelState.AddModelError(string.Empty, "Assign a new admin before making this one an author");
+                    evm.UserTypes = _userProfileRepository.GetUserTypes();
+                    return View(evm);
+                }                
                 _userProfileRepository.Update(evm.User);
 
                 return RedirectToAction("Index");

--- a/TabloidMVC/Controllers/UserProfileController.cs
+++ b/TabloidMVC/Controllers/UserProfileController.cs
@@ -117,6 +117,15 @@ namespace TabloidMVC.Controllers
         {
             try
             {
+                if (userProfile.UserTypeId == 1)
+                {
+                    List<UserProfile> allAdmins = _userProfileRepository.GetAllActiveAdmins();
+                    if (allAdmins.Count == 1)
+                    {
+                        ModelState.AddModelError(string.Empty, "Assign new admin before deleting this one");
+                        return View(userProfile);
+                    }
+                }
                 userProfile.Deactivated = true;
                 _userProfileRepository.Update(userProfile);
                 return RedirectToAction(nameof(Index));

--- a/TabloidMVC/Repositories/IUserProfileRepository.cs
+++ b/TabloidMVC/Repositories/IUserProfileRepository.cs
@@ -6,8 +6,8 @@ namespace TabloidMVC.Repositories
     public interface IUserProfileRepository
     {
         List<UserProfile> GetAllActive();
+        List<UserProfile> GetAllActiveAdmins();
         List<UserProfile> GetDeactivated();
-
         UserProfile GetByEmail(string email);
         UserProfile GetById(int id);
         List<UserType> GetUserTypes();

--- a/TabloidMVC/Repositories/UserProfileRepository.cs
+++ b/TabloidMVC/Repositories/UserProfileRepository.cs
@@ -60,6 +60,57 @@ namespace TabloidMVC.Repositories
                 }
             }
         }
+
+        public List<UserProfile> GetAllActiveAdmins()
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                       SELECT u.id, u.FirstName, u.LastName, u.DisplayName, u.Email,
+                              u.CreateDateTime, u.ImageLocation, u.UserTypeId, u.Deactivated,
+                              ut.[Name] AS UserTypeName
+                         FROM UserProfile u
+                              LEFT JOIN UserType ut ON u.UserTypeId = ut.id
+                         WHERE u.Deactivated = 0 AND u.UserTypeId = 1
+                         ORDER BY u.DisplayName";
+
+                    var reader = cmd.ExecuteReader();
+
+                    List<UserProfile> userProfiles = new List<UserProfile>();
+
+                    while (reader.Read())
+                    {
+                        UserProfile userProfile = new UserProfile()
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                            Email = reader.GetString(reader.GetOrdinal("Email")),
+                            FirstName = reader.GetString(reader.GetOrdinal("FirstName")),
+                            LastName = reader.GetString(reader.GetOrdinal("LastName")),
+                            DisplayName = reader.GetString(reader.GetOrdinal("DisplayName")),
+                            CreateDateTime = reader.GetDateTime(reader.GetOrdinal("CreateDateTime")),
+                            Deactivated = reader.GetBoolean(reader.GetOrdinal("Deactivated")),
+                            ImageLocation = DbUtils.GetNullableString(reader, "ImageLocation"),
+                            UserTypeId = reader.GetInt32(reader.GetOrdinal("UserTypeId")),
+                            UserType = new UserType()
+                            {
+                                Id = reader.GetInt32(reader.GetOrdinal("UserTypeId")),
+                                Name = reader.GetString(reader.GetOrdinal("UserTypeName"))
+                            },
+                        };
+
+                        userProfiles.Add(userProfile);
+                    }
+
+                    reader.Close();
+
+                    return userProfiles;
+                }
+            }
+        }
+
         public List<UserProfile> GetDeactivated()
         {
             using (var conn = Connection)

--- a/TabloidMVC/Views/UserProfile/Delete.cshtml
+++ b/TabloidMVC/Views/UserProfile/Delete.cshtml
@@ -42,7 +42,7 @@
                 </dd>
             </dl>
             <div class="form-group">
-                @Html.ValidationSummary(false, "", new { @class = "text-danger" })
+                <div asp-validation-summary="ModelOnly" class="text-danger"></div>
                 <input type="submit" value="Deactivate" class="btn btn-danger btn-block" />
                 <a class="btn btn-primary btn-block" asp-controller="UserProfile" asp-action="Index">Cancel</a>
             </div>

--- a/TabloidMVC/Views/UserProfile/Delete.cshtml
+++ b/TabloidMVC/Views/UserProfile/Delete.cshtml
@@ -42,6 +42,7 @@
                 </dd>
             </dl>
             <div class="form-group">
+                @Html.ValidationSummary(false, "", new { @class = "text-danger" })
                 <input type="submit" value="Deactivate" class="btn btn-danger btn-block" />
                 <a class="btn btn-primary btn-block" asp-controller="UserProfile" asp-action="Index">Cancel</a>
             </div>


### PR DESCRIPTION
# Description
Prevent the deactivation of all admins by making sure one admin is always active. Display an error to the browser when an attempt to deactivate the final admin is made. Display an error if an attempt is made to make the final admin an author.
Fixes #29 
## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
# Testing Instructions
1. Run the app
2. Make sure only one admin is present. Either rerun the seed data (and restart the app) or deactivate any other admins.
3. Attempt to deactivate the final admin.
4. You will still see the confirmation page, but if you attempt to confirm, a message will display and you will be prevented from completing the deletion.
5. Attempt to make the final admin an author. You should see similar results to a deletion attempt.
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
