### PR TITLE
Restricted edit and tags functionality in post details for non-users

### DIFF
--- a/TabloidMVC/Controllers/PostController.cs
+++ b/TabloidMVC/Controllers/PostController.cs
@@ -44,7 +44,7 @@ namespace TabloidMVC.Controllers
             
             if (post == null)return NotFound();
 
-            if (post.UserProfileId != int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier))) return RedirectToAction("Index", "Post");
+            if (post.UserProfileId != int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)) && (post.PublishDateTime > DateTime.Now || post.PublishDateTime == null) ) return RedirectToAction("Index", "Post");
 
             int WordCount = post.Content.Split(" ").Length;
 
@@ -52,7 +52,8 @@ namespace TabloidMVC.Controllers
             {
                 Post = post,
                 ReadTime = WordCount % 265 == 0 ? WordCount / 265 : WordCount / 265 + 1,
-                PostTags = _tagRepository.GetPostTags(id)
+                PostTags = _tagRepository.GetPostTags(id),
+                CurrentUserProfileId = GetCurrentUserProfileId()
         };            
             return View(pdv);
         }

--- a/TabloidMVC/Models/ViewModels/PostDetailView.cs
+++ b/TabloidMVC/Models/ViewModels/PostDetailView.cs
@@ -7,5 +7,6 @@ namespace TabloidMVC.Models.ViewModels
         public Post Post { get; set; }
         public double ReadTime { get; set; }
         public List<Tag> PostTags { get; set; }
+        public int CurrentUserProfileId { get; set; }
     }
 }

--- a/TabloidMVC/Views/Post/Details.cshtml
+++ b/TabloidMVC/Views/Post/Details.cshtml
@@ -21,14 +21,17 @@
                 <p class="text-secondary">Estimated read time: @Model.ReadTime @minuteForm</p>
             </div>
             <div class="row">
-                <a asp-action="Edit" asp-route-id="@Model.Post.Id" class="btn btn-outline-primary mx-1" title="Edit">
-                    <i class="fas fa-pencil-alt"></i>
-                </a>
+                @if (Model.Post.UserProfileId == Model.CurrentUserProfileId)
+                {
+                    <a asp-action="Edit" asp-route-id="@Model.Post.Id" class="btn btn-outline-primary mx-1" title="Edit">
+                        <i class="fas fa-pencil-alt"></i>
+                    </a>
+                    <a asp-controller="Tag" asp-action="TagManager" asp-route-id="@Model.Post.Id" class="btn btn-outline-primary mx-1" title="Tag Manager">
+                        <i class="fa fa-tags"></i>
+                    </a>
+                }
                 <a asp-action="Delete" asp-route-id="@Model.Post.Id" class="btn btn-outline-primary mx-1" title="Delete">
                     <i class="fas fa-trash"></i>
-                </a>
-                <a asp-controller="Tag" asp-action="TagManager" asp-route-id="@Model.Post.Id" class="btn btn-outline-primary mx-1" title="Tag Manager">
-                    <i class="fa fa-tags"></i>
                 </a>
             </div>
         </section>


### PR DESCRIPTION
# Description
Fixed bug allowing non-author of post to edit and modify tags in details view. Only author of post is able to see the edit and tag management buttons on their posts.
## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
# Testing Instructions
- Log in as a different user and view another user's post details
- User should not be able to see the edit or tag management buttons
- View a post user has written
- User should see the edit and tag management buttons
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
