### PR TITLE
updated tag manager to pull from all posts rather than published posts

### DIFF
--- a/TabloidMVC/Controllers/TagController.cs
+++ b/TabloidMVC/Controllers/TagController.cs
@@ -179,6 +179,13 @@ namespace TabloidMVC.Controllers
                         }
                     }
                 }
+                else
+                {
+                    foreach (int tagId in previouslySelectedTagIds)
+                    {
+                        _tagRepo.RemoveTagFromPost(tagId, id);
+                    }
+                }
 
                 return RedirectToAction("Details", "Post", new { id = id });
             }

--- a/TabloidMVC/Controllers/TagController.cs
+++ b/TabloidMVC/Controllers/TagController.cs
@@ -131,7 +131,7 @@ namespace TabloidMVC.Controllers
 
             AddTagPostViewModel vm = new AddTagPostViewModel
             {
-                Post = _postRepo.GetPublishedPostById(Id),
+                Post = _postRepo.GetPostById(Id),
                 Tags = _tagRepo.GetAllTags(),
                 CurrentTagIds = new List<int>()
             };

--- a/TabloidMVC/appsettings.json
+++ b/TabloidMVC/appsettings.json
@@ -8,6 +8,6 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultConnection": "server=localhost\\SQLEXPRESS06;database=TabloidMVC;integrated security=true;"
+    "DefaultConnection": "server=localhost\\SQLEXPRESS;database=TabloidMVC;integrated security=true;"
   }
 }


### PR DESCRIPTION
# Description
- bugfix: program would crash if the tag manager was accessed from an unpublished post
- bugfix: updated tag manager to handle null value if no tags were selected

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
# Testing Instructions
- select an unpublished post and access the tag manager
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
