### PR TITLE
Edit hover names of deactivate/reactivate buttons

### DIFF
--- a/TabloidMVC/Views/UserProfile/Deactivated.cshtml
+++ b/TabloidMVC/Views/UserProfile/Deactivated.cshtml
@@ -40,7 +40,7 @@
                         @Html.DisplayFor(modelItem => item.UserType.Name)
                     </td>
                     <td>
-                        <a asp-action="Reactivate" asp-route-id="@item.Id" class="btn btn-outline-success mx-1" title="Delete">
+                        <a asp-action="Reactivate" asp-route-id="@item.Id" class="btn btn-outline-success mx-1" title="Reactivate User">
                             <i class="fas fa-power-off"></i>
                         </a>
                     </td>

--- a/TabloidMVC/Views/UserProfile/Index.cshtml
+++ b/TabloidMVC/Views/UserProfile/Index.cshtml
@@ -46,7 +46,7 @@
                         <a asp-action="Edit" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Edit">
                             <i class="fas fa-pencil-alt"></i>
                         </a>
-                        <a asp-action="Delete" asp-route-id="@item.Id" class="btn btn-outline-danger mx-1" title="Delete">
+                        <a asp-action="Delete" asp-route-id="@item.Id" class="btn btn-outline-danger mx-1" title="Deactivate User">
                             <i class="fas fa-power-off"></i>
                         </a>
                     </td>


### PR DESCRIPTION
# Description
Small aesthetic change: when hovering over the deactivate or reactive buttons in the user profile lists, the hover popup now says "Deactivate User" and "Reactivate User," respectively.
Fixes # n/s
## Type of change
- [x] New feature (non-breaking change which adds functionality)
# Testing Instructions
1. Run the app and login
2. Navigate to Admin Tools > User Profiles
3. Hover over the deactivate button by a user profile to see "Deactivate User"
4. Navigate to Deactivated Users
5. Hover over the reactivate button to see "Reactivate User"
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
